### PR TITLE
B0.4.2

### DIFF
--- a/app/src/main/java/com/example/samuel/medimagem/ExameActivity.java
+++ b/app/src/main/java/com/example/samuel/medimagem/ExameActivity.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -17,7 +18,7 @@ import android.view.View;
 import android.widget.Toast;
 import android.widget.Toolbar;
 
-public class ExameActivity extends AppCompatActivity implements ExameAgendadosFragment.OnExameAgendadoInteractionListener, ExamesFeitoFragment.OnExameFeitoInteractionListener {
+public class ExameActivity extends AppCompatActivity implements ExameAgendadosFragment.OnExameAgendadoInteractionListener, ExamesFeitoFragment.OnExameFeitoInteractionListener, ViewPager.OnPageChangeListener {
 
 
     private ViewPager viewPager;
@@ -98,7 +99,7 @@ public class ExameActivity extends AppCompatActivity implements ExameAgendadosFr
         tabLayout.setupWithViewPager(viewPager);
         viewPager.setSaveFromParentEnabled(false);
         viewPager.setOffscreenPageLimit(1);
-        viewPager.addOnPageChangeListener(new TabLayout.TabLayoutOnPageChangeListener(tabLayout));
+        viewPager.addOnPageChangeListener(this);
 
         tabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
             @Override
@@ -147,5 +148,23 @@ public class ExameActivity extends AppCompatActivity implements ExameAgendadosFr
                 finish();
             }
         }
+    }
+
+    @Override
+    public void onPageScrolled(int i, float v, int i1) {
+
+    }
+
+    @Override
+    public void onPageSelected(int i) {
+        Fragment fragment = pagerAdapter.getFragment(i);
+        if (fragment != null){
+            fragment.onResume();
+        }
+    }
+
+    @Override
+    public void onPageScrollStateChanged(int i) {
+
     }
 }

--- a/app/src/main/java/com/example/samuel/medimagem/ExameAgendadosFragment.java
+++ b/app/src/main/java/com/example/samuel/medimagem/ExameAgendadosFragment.java
@@ -12,7 +12,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * A fragment representing a list of Items.
@@ -31,6 +33,7 @@ public class ExameAgendadosFragment extends Fragment {
     private int medico;
     private ExamesAgendadosAdapter adapter;
     private RecyclerView recyclerView;
+    private boolean canRunBG = true;
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
@@ -58,6 +61,7 @@ public class ExameAgendadosFragment extends Fragment {
         }
 
         carregarExame();
+        logCompare();
 
         setRetainInstance(true);
     }
@@ -92,6 +96,10 @@ public class ExameAgendadosFragment extends Fragment {
             adapter = new ExamesAgendadosAdapter(listaExames, mListener);
 
             recyclerView.setAdapter(adapter);
+
+            RecyclerSectionItemDecoration sectionItemDecoration = new RecyclerSectionItemDecoration(getResources().getDimensionPixelSize(R.dimen.header), true, getSectionCallback(listaExames));
+
+
 
         }
         Log.i("DEBUG", "view created");
@@ -141,6 +149,12 @@ public class ExameAgendadosFragment extends Fragment {
 
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        atualizarLista();
+    }
+
     /**
      * This interface must be implemented by activities that contain this
      * fragment to allow an interaction in this fragment to be communicated
@@ -157,11 +171,46 @@ public class ExameAgendadosFragment extends Fragment {
         void onExameAgendadoLongInteraction(int position);
     }
 
+    private RecyclerSectionItemDecoration.SectionCallback getSectionCallback(final ArrayList<Exam> listaExames){
+        return new RecyclerSectionItemDecoration.SectionCallback() {
+            @Override
+            public boolean isSection(int position) {
+                return position == 0 || listaExames.get(position).getHoraData().compareTo(listaExames.get(position-1).getHoraData()) != 0;
+            }
+
+            @Override
+            public CharSequence getSectionHeader(int position) {
+                SimpleDateFormat dateFormat = new SimpleDateFormat("dd 'de' MMMM 'de' yyyy", new Locale("pt", "BR"));
+
+                return dateFormat.format(listaExames.get(position).getHoraData());
+            }
+        };
+    }
+
+    private void logCompare(){
+        for (int i = 0; i<listaExames.size(); i++){
+                if (i != 0){
+                    Log.i("DEBUG", String.valueOf(listaExames.get(i).getHoraData().getDate() - listaExames.get(i).getHoraData().getDate()));
+                }
+        }
+    }
+
     private class AtualizarListaTask extends AsyncTask<Void, Void, ArrayList<Exam>>{
 
         @Override
+        protected void onPreExecute() {
+
+            super.onPreExecute();
+        }
+
+        @Override
         protected ArrayList<Exam> doInBackground(Void... voids) {
-            ExameAgendadosFragment.this.carregarExame();
+            if (canRunBG){
+                canRunBG = false;
+                ExameAgendadosFragment.this.carregarExame();
+                canRunBG = true;
+            }
+
             return null;
         }
 
@@ -174,4 +223,6 @@ public class ExameAgendadosFragment extends Fragment {
             super.onPostExecute(aVoid);
         }
     }
+
+
 }

--- a/app/src/main/java/com/example/samuel/medimagem/ExamesAgendadosAdapter.java
+++ b/app/src/main/java/com/example/samuel/medimagem/ExamesAgendadosAdapter.java
@@ -1,7 +1,5 @@
 package com.example.samuel.medimagem;
 
-import android.content.Context;
-import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -14,7 +12,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.Locale;
 
 public class ExamesAgendadosAdapter extends RecyclerView.Adapter<ExamesAgendadosAdapter.BaseViewHolder> {
@@ -31,12 +28,22 @@ public class ExamesAgendadosAdapter extends RecyclerView.Adapter<ExamesAgendados
         Collections.sort(exames, new Comparator<Exam>() {
             @Override
             public int compare(Exam o1, Exam o2) {
-                return o1.getHoraData().compareTo(o2.getHoraData());
+                return o1.getHoraData().getDate() - o2.getHoraData().getDate();
             }
         });
 
+        Collections.sort(exames, new Comparator<Exam>() {
+            @Override
+            public int compare(Exam o1, Exam o2) {
+                long value = o1.getHoraData().getTime() - o2.getHoraData().getTime();
+                int ret = (int) value;
+                return ret;
+            }
+        });
+
+
         for (int i = 0; i<exames.size(); i++){
-            if (i == 0 || exames.get(i).getHoraData().compareTo(exames.get(i-1).getHoraData()) > 0){
+            if (i == 0 || exames.get(i).getHoraData().getDate() - exames.get(i-1).getHoraData().getDate() > 0){
                 Exam header = new Exam();
                 header.setViewType(1);
                 header.setHoraData(exames.get(i).getHoraData());

--- a/app/src/main/java/com/example/samuel/medimagem/ExamesPagerAdapter.java
+++ b/app/src/main/java/com/example/samuel/medimagem/ExamesPagerAdapter.java
@@ -5,6 +5,10 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
+import android.view.ViewGroup;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ExamesPagerAdapter extends FragmentStatePagerAdapter {
 
@@ -12,12 +16,16 @@ public class ExamesPagerAdapter extends FragmentStatePagerAdapter {
     int medicoID;
     ExameAgendadosFragment exameAgendadosFragment;
     ExamesFeitoFragment examesFeitoFragment;
+    private Map<Integer, String> fragmentTags;
+    private FragmentManager fm;
 
 
     public ExamesPagerAdapter(FragmentManager fm, int medicoID) {
         super(fm);
+        this.fm = fm;
         this.tabsNum = 2;
         this.medicoID = medicoID;
+        fragmentTags = new HashMap<>();
     }
 
     @Override
@@ -66,6 +74,27 @@ public class ExamesPagerAdapter extends FragmentStatePagerAdapter {
         return super.getPageTitle(position);
     }
 
+    @NonNull
+    @Override
+    public Object instantiateItem(@NonNull ViewGroup container, int position) {
+        Object object = super.instantiateItem(container, position);
+        if (object instanceof Fragment){
+            Fragment fragment = (Fragment) object;
+            String tag = fragment.getTag();
+            fragmentTags.put(position, tag);
+        }
+        return object;
+
+    }
+
+    public Fragment getFragment(int position){
+        Fragment fragment = null;
+        String tag = fragmentTags.get(position);
+        if (tag != null){
+            fragment = fm.findFragmentByTag(tag);
+        }
+        return fragment;
+    }
 
     @Override
     public int getItemPosition(@NonNull Object object) {

--- a/app/src/main/java/com/example/samuel/medimagem/RecyclerSectionItemDecoration.java
+++ b/app/src/main/java/com/example/samuel/medimagem/RecyclerSectionItemDecoration.java
@@ -1,0 +1,57 @@
+package com.example.samuel.medimagem;
+
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import com.example.samuel.medimagem.R;
+
+public class RecyclerSectionItemDecoration extends RecyclerView.ItemDecoration {
+    private final int headerOffset;
+    private final boolean sticky;
+    private final SectionCallback sectionCallback;
+
+    private View headerView;
+    private TextView header;
+
+    public RecyclerSectionItemDecoration(int headerHeight, boolean sticky, @NonNull SectionCallback sectionCallback){
+        headerOffset = headerHeight;
+        this.sticky = sticky;
+        this.sectionCallback = sectionCallback;
+    }
+
+    @Override
+    public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+        super.getItemOffsets(outRect, view, parent, state);
+
+        int pos = parent.getChildAdapterPosition(view);
+        if (sectionCallback.isSection(pos)){
+            outRect.top = headerOffset;
+        }
+    }
+
+    @Override
+    public void onDrawOver(@NonNull Canvas c, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+        super.onDrawOver(c, parent, state);
+
+        if (headerView == null){
+            headerView = inflateHeaderView(parent);
+            header = (TextView) headerView.findViewById(R.id.data_exame_header);
+            fixLayoutSize(headerView, parent);
+        }
+
+        CharSequence previousHeader = "";
+        for (int i = 0; i<parent.getChildCount(); i++){
+            View child = parent.getChildAt(i);
+        }
+    }
+
+    public interface SectionCallback {
+        boolean isSection(int position);
+
+        CharSequence getSectionHeader(int position);
+    }
+}

--- a/app/src/main/java/com/example/samuel/medimagem/RecyclerSectionItemDecoration.java
+++ b/app/src/main/java/com/example/samuel/medimagem/RecyclerSectionItemDecoration.java
@@ -4,10 +4,10 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.TextView;
-
-import com.example.samuel.medimagem.R;
 
 public class RecyclerSectionItemDecoration extends RecyclerView.ItemDecoration {
     private final int headerOffset;
@@ -46,8 +46,44 @@ public class RecyclerSectionItemDecoration extends RecyclerView.ItemDecoration {
         CharSequence previousHeader = "";
         for (int i = 0; i<parent.getChildCount(); i++){
             View child = parent.getChildAt(i);
+            final int position = parent.getChildAdapterPosition(child);
+
+            CharSequence title = sectionCallback.getSectionHeader(position);
+            header.setText(title);
+            if (!previousHeader.equals(title) || sectionCallback.isSection(position)){
+                drawHeader(c, child, headerView);
+                previousHeader = title;
+            }
         }
     }
+
+    private void drawHeader(Canvas c, View child, View headerView){
+        c.save();
+        if (sticky){
+            c.translate(0, Math.max(0, child.getTop() - headerView.getHeight()));
+        } else {
+            c.translate(0, child.getTop() - headerView.getHeight());
+        }
+        headerView.draw(c);
+        c.restore();
+    }
+
+    private View inflateHeaderView(RecyclerView parent){
+        return LayoutInflater.from(parent.getContext()).inflate(R.layout.exame_agendado_header, parent, false);
+    }
+
+    private void fixLayoutSize(View view, ViewGroup parent){
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(parent.getWidth(), View.MeasureSpec.EXACTLY);
+        int heightSpec = View.MeasureSpec.makeMeasureSpec(parent.getHeight(), View.MeasureSpec.UNSPECIFIED);
+
+        int childWidth = ViewGroup.getChildMeasureSpec(widthSpec, parent.getPaddingLeft() + parent.getPaddingRight(), view.getLayoutParams().width);
+        int childHeigth = ViewGroup.getChildMeasureSpec(heightSpec, parent.getPaddingTop() + parent.getPaddingBottom(), view.getLayoutParams().height);
+
+        view.measure(childWidth, childHeigth);
+
+        view.layout(0, 0 , view.getMeasuredWidth(), view.getMeasuredHeight());
+    }
+
 
     public interface SectionCallback {
         boolean isSection(int position);

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="text_margin">16dp</dimen>
+    <dimen name="header">25dp</dimen>
 </resources>


### PR DESCRIPTION
## Bugs Corrigidos

#### Ao Rotacionar a tela
O aplicativo poderia crashar ao rotacionar a tela duas vezes seguidas.

#### Cabeçalhos das listas duplos
Ao carregar a lista de exames agendados, dois exames na mesma data mas em horários diferentes poderiam aparecer com um cabeçalho cada um.

#### Ao Cadastrar exames
Quando cadastrava um exame, o exame era salvo no banco de dados, mas a lista não era atualizada.

## Extras
#### Ordenação por hora
Agora os exames de um mesmo dia são ordenados por horário.